### PR TITLE
correccion en emitir remito porfa revisar

### DIFF
--- a/Almacenes/OrdenEntregaAlmacen.cs
+++ b/Almacenes/OrdenEntregaAlmacen.cs
@@ -54,6 +54,11 @@ namespace TPGrupoE.Almacenes
             return ordenesEntrega.FindAll(o => o.Estado == EstadoOrdenEntrega.Pendiente);
         }
 
+        public static List<OrdenEntregaEntidad> BuscarOrdenesDeEntregaCumplidas()
+        {
+            return ordenesEntrega.FindAll(o => o.Estado == EstadoOrdenEntrega.Cumplida);
+        }
+
         public static OrdenEntregaEntidad BuscarOrdenPorId(int id)
         {
             return ordenesEntrega.FirstOrDefault(oe => oe.IdOrdenEntrega == id);

--- a/CasosDeUso/CU8EmitirRemito/Model/EmitirRemitoModel.cs
+++ b/CasosDeUso/CU8EmitirRemito/Model/EmitirRemitoModel.cs
@@ -34,7 +34,7 @@ namespace TPGrupoE.CasosDeUso.CU8EmitirRemito.Model
         public void CargarOrdenesPorTransportista(string dniTransportista)
         {
             OrdenesDePreparacion = [];
-            var ordenesDeEntregaParaDespacho = OrdenEntregaAlmacen.BuscarOrdenesParaDespachar();
+            var ordenesDeEntregaParaDespacho = OrdenEntregaAlmacen.BuscarOrdenesDeEntregaCumplidas();
 
             foreach (var ordenEntrega in ordenesDeEntregaParaDespacho)
             {


### PR DESCRIPTION
Bri, ahora la logica es que en emitir remito las oe esten cumplidas. El tema es que si creo una OP de 0 sí aparece, pero si quiero despachar las que tenemos por defecto no aparece. ademas es raro porque si entro directo a emitir remito me aparecen 2 dni sin ninguna op a despachar. ahora cuando creo una nueva op, se agregan mas dnis y solo coincide como op para despachar la nueva que creé @brisatames 